### PR TITLE
Move container logs to host-controlled directory to prevent symlink overwrite

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -286,7 +286,9 @@ export async function runContainerAgent(
     "Spawning container agent",
   );
 
-  const logsDir = path.join(groupDir, "logs");
+  // Store host-side container logs outside the container-writable group directory.
+  // This prevents symlink/hardlink redirection attacks from untrusted group content.
+  const logsDir = path.join(DATA_DIR, "logs", group.folder);
   fs.mkdirSync(logsDir, { recursive: true });
 
   return new Promise((resolve) => {


### PR DESCRIPTION
### Motivation
- Prevent untrusted container content in `groups/<folder>/logs` from creating symlinks/hardlinks that let the host overwrite arbitrary files when writing per-run container logs.

### Description
- Change host-side log path from the container-writable `groups/<folder>/logs` to the host-controlled `DATA_DIR/logs/<group-folder>` and add an inline comment explaining the security rationale, while preserving existing log content and behavior.

### Testing
- Ran `pnpm -s format:check`, `pnpm -s typecheck`, and `pnpm -s test`, and all automated checks and tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b9b3fe188329b9b7e8ad65b668de)