### PR TITLE
fix: keep credential proxy loopback-only when docker0 is unavailable

### DIFF
--- a/src/container-runtime-bind-host.test.ts
+++ b/src/container-runtime-bind-host.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type NetIf = ReturnType<(typeof import("os"))["networkInterfaces"]>;
+
+async function loadRuntime(opts: {
+  envHost?: string;
+  platform?: NodeJS.Platform;
+  hasWslInterop?: boolean;
+  ifaces?: NetIf;
+}) {
+  vi.resetModules();
+
+  if (opts.envHost) process.env.CREDENTIAL_PROXY_HOST = opts.envHost;
+  else delete process.env.CREDENTIAL_PROXY_HOST;
+
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  vi.doMock("./logger.js", () => ({ logger }));
+  vi.doMock("os", async () => {
+    const actual = await vi.importActual<typeof import("os")>("os");
+    return {
+      ...actual,
+      default: {
+        ...(actual as unknown as Record<string, unknown>),
+        platform: () => opts.platform ?? "linux",
+        networkInterfaces: () => opts.ifaces ?? {},
+      },
+      platform: () => opts.platform ?? "linux",
+      networkInterfaces: () => opts.ifaces ?? {},
+    };
+  });
+  vi.doMock("fs", async () => {
+    const actual = await vi.importActual<typeof import("fs")>("fs");
+    return {
+      ...actual,
+      default: {
+        ...(actual as unknown as Record<string, unknown>),
+        existsSync: () => opts.hasWslInterop ?? false,
+      },
+      existsSync: () => opts.hasWslInterop ?? false,
+    };
+  });
+
+  const runtime = await import("./container-runtime.js");
+  return { runtime, logger };
+}
+
+describe("PROXY_BIND_HOST", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CREDENTIAL_PROXY_HOST;
+  });
+
+  it("binds to docker0 IPv4 on Linux when available", async () => {
+    const ifaces = {
+      docker0: [
+        { address: "172.17.0.1", family: "IPv4", internal: false, netmask: "", mac: "", cidr: "" },
+      ],
+    } as NetIf;
+    const { runtime, logger } = await loadRuntime({ ifaces });
+
+    expect(runtime.PROXY_BIND_HOST).toBe("172.17.0.1");
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to loopback instead of 0.0.0.0 when docker0 is missing", async () => {
+    const { runtime, logger } = await loadRuntime({ ifaces: {} as NetIf });
+
+    expect(runtime.PROXY_BIND_HOST).toBe("127.0.0.1");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "docker0 bridge not found; binding credential proxy to loopback for safety. Set CREDENTIAL_PROXY_HOST to override.",
+    );
+  });
+});

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -18,7 +18,7 @@ export const CONTAINER_HOST_GATEWAY = "host.docker.internal";
  * Address the credential proxy binds to.
  * Docker Desktop (macOS): 127.0.0.1 — the VM routes host.docker.internal to loopback.
  * Docker (Linux): bind to the docker0 bridge IP so only containers can reach it,
- *   falling back to 0.0.0.0 if the interface isn't found.
+ *   falling back to 127.0.0.1 if the interface isn't found.
  */
 export const PROXY_BIND_HOST = process.env.CREDENTIAL_PROXY_HOST || detectProxyBindHost();
 
@@ -29,14 +29,17 @@ function detectProxyBindHost(): string {
   // Check /proc filesystem, not env vars — WSL_DISTRO_NAME isn't set under systemd.
   if (fs.existsSync("/proc/sys/fs/binfmt_misc/WSLInterop")) return "127.0.0.1";
 
-  // Bare-metal Linux: bind to the docker0 bridge IP instead of 0.0.0.0
+  // Bare-metal Linux: bind to the docker0 bridge IP.
   const ifaces = os.networkInterfaces();
   const docker0 = ifaces["docker0"];
   if (docker0) {
     const ipv4 = docker0.find((a) => a.family === "IPv4");
     if (ipv4) return ipv4.address;
   }
-  return "0.0.0.0";
+  logger.warn(
+    "docker0 bridge not found; binding credential proxy to loopback for safety. Set CREDENTIAL_PROXY_HOST to override.",
+  );
+  return "127.0.0.1";
 }
 
 /** CLI args needed for the container to resolve the host gateway. */


### PR DESCRIPTION
### Motivation
- The credential proxy previously fell back to binding `0.0.0.0` when the `docker0` bridge wasn't found, which could expose credential-injecting behavior to external networks and leak API credentials.
- The goal is a minimal safety-first change that prevents accidental exposure while preserving container-local reachability when possible.

### Description
- Changed `detectProxyBindHost()` in `src/container-runtime.ts` to return `127.0.0.1` (loopback) instead of `0.0.0.0` when no `docker0` interface is detected. 
- Added a `logger.warn` message on that fallback path advising operators they can override with `CREDENTIAL_PROXY_HOST` if a different bind host is required. 
- Kept existing behavior for macOS and WSL (still bind to `127.0.0.1`) and for Linux with a `docker0` interface (bind to the bridge IPv4). 
- Added a focused test file `src/container-runtime-bind-host.test.ts` verifying that Linux + `docker0` yields the bridge IP and Linux without `docker0` falls back to loopback and emits the warning.

### Testing
- Ran `pnpm typecheck` and it completed successfully. 
- Ran formatting checks with `pnpm format:check` (fixed formatting on the new test file and re-checked); format check passed. 
- Ran unit tests for the added/related files with `pnpm test -- src/container-runtime-bind-host.test.ts` and also ran `pnpm test -- src/container-runtime-bind-host.test.ts src/container-runtime.test.ts`; the focused tests passed. 
- The repository test run showed all tests passing: `237` tests passed in total.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a95b0bac83299275e555fcd81b56)