### PR TITLE
Isolate uv cache mount per container group

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -111,8 +111,8 @@ function buildVolumeMounts(group: RegisteredGroup, isMain: boolean): VolumeMount
     }
   }
 
-  // Persistent uv cache across container restarts (shared across all groups)
-  const uvCacheDir = path.join(DATA_DIR, "cache", "uv");
+  // Persistent uv cache across container restarts (isolated per group)
+  const uvCacheDir = path.join(DATA_DIR, "cache", "uv", group.folder);
   fs.mkdirSync(uvCacheDir, { recursive: true });
   mounts.push({
     hostPath: uvCacheDir,


### PR DESCRIPTION
### Motivation
- Prevent cross-group data leakage and cache poisoning by removing the single shared writable uv cache that was mounted into every container.

### Description
- Update `buildVolumeMounts` in `src/container-runner.ts` to mount a per-group host path `path.join(DATA_DIR, "cache", "uv", group.folder)` (instead of the project-wide `DATA_DIR/cache/uv`) while preserving creation and the container path `/home/node/.cache/uv`.

### Testing
- Ran `npm test` which passed (all automated tests completed successfully); repository format, lint, and typecheck scripts (`npm run format:fix`, `npm run lint`, `npm run typecheck`) also ran and succeeded; a prior attempt to run `npm test -- --runInBand` failed due to Vitest rejecting the `--runInBand` CLI flag, which is a test runner flag mismatch and not a code failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a9d6a5e0832983247d1e5a482360)