### PR TITLE
fix(ci): harden version bump workflow token handling

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,10 +18,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 
       - name: Bump patch version
+        env:
+          npm_config_ignore_scripts: "true"
         run: |
           pnpm version patch --no-git-tag-version
           git add package.json pnpm-lock.yaml
@@ -31,4 +34,4 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           git commit -m "chore: bump version to $VERSION"
           git pull --rebase
-          git push
+          git push https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git HEAD:${{ github.ref_name }}


### PR DESCRIPTION
### Motivation
- The `bump-version` workflow used a GitHub App token with `actions/checkout` and ran `pnpm version` without ignoring lifecycle scripts, allowing a malicious `preversion`/`postversion` script to execute and potentially read persisted git credentials.
- The goal is to remove the credential persistence window and prevent lifecycle script execution while preserving the automated version-bump behavior.

### Description
- Set `persist-credentials: false` on `actions/checkout@v4` to prevent the App token from being written into local git config.
- Disable npm lifecycle scripts for the bump step by setting `npm_config_ignore_scripts: "true"` in the `Bump patch version` step.
- Replace the generic `git push` with an explicit tokenized push URL for the single push operation so the token is only used for the final push and not persisted in the repo environment.

### Testing
- Ran repository hooks during commit which executed `format:fix`, `lint`, and `typecheck` successfully.
- Executed `pnpm lint && pnpm typecheck` which both completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b4b7e4b88329b115878d189b2147)