### PR TITLE
fix: skip lifecycle scripts during Docker prod prune

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN pnpm run build
 # Prune dev dependencies so node_modules is production-ready.
 # This keeps the already-compiled better-sqlite3 native module
 # without needing build tools in the production stage.
-RUN pnpm prune --prod
+RUN pnpm prune --prod --ignore-scripts
 
 # --- Production stage ---
 FROM node:24-slim


### PR DESCRIPTION
## Summary
- Fixes Docker build failure where `pnpm prune --prod` removes husky (devDependency), then the `prepare` lifecycle script tries to run it and fails with `sh: 1: husky: not found`
- Adds `--ignore-scripts` flag to skip lifecycle scripts during prune

## Context
After merging #42 (action upgrades + Node 24), the release workflow successfully bumped the version but the host image build failed at the prune step.

## Test plan
- [x] `pnpm run check` — all 703 tests pass
- [ ] Merge and verify host image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)